### PR TITLE
Fix room syncing

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,6 @@
 {
   "printWidth": 100,
-  "semi": false
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "all"
 }

--- a/client/engine/index.js
+++ b/client/engine/index.js
@@ -4,29 +4,43 @@ import mapObjectsData from './config/MapObjectsData'
 import mapItemsData from './config/MapItemsData'
 
 //MODELS
-var Player = require('./models/Player');
-var Bullet = require('./models/Bullet');
-var MapTiles = require('./models/MapTiles');
-var MapObjects = require('./models/MapObjects');
-var MapItems = require('./models/MapItems');
-var Projectiles = require('./models/Projectiles');
+var Player = require('./models/Player')
+var Bullet = require('./models/Bullet')
+var MapTiles = require('./models/MapTiles')
+var MapObjects = require('./models/MapObjects')
+var MapItems = require('./models/MapItems')
+var Projectiles = require('./models/Projectiles')
 
 //FACTORIES
-var MapObjectFactory = require('./utils/MapObjectFactory');
-var MapItemFactory = require('./utils/MapItemFactory');
+var MapObjectFactory = require('./utils/MapObjectFactory')
+var MapItemFactory = require('./utils/MapItemFactory')
 
 //HELPERS/DEFAULTS
-var Keys = require('./utils/keys');
-var assetsHelpers = require('./config/assets');
-var debounce = require('./utils/debounce');
-var getDirection = require('./utils/getDirection');
+var Keys = require('./utils/keys')
+var assetsHelpers = require('./config/assets')
+var debounce = require('./utils/debounce')
+var getDirection = require('./utils/getDirection')
 import spawnPoints from './utils/spawnPoints'
 
 //SOUND FX
-var playSound = require('./utils/playSound.js');
+var playSound = require('./utils/playSound.js')
 
 // GLOBALS
-var player, map, projectiles, mapObjects, mapItems, bullets, startTime, raf, ctx, canvas = {}, assets, keys, players = {}, sounds;
+var player,
+  map,
+  projectiles,
+  mapObjects,
+  mapItems,
+  bullets,
+  startTime,
+  raf,
+  ctx,
+  canvas = {},
+  assets,
+  keys,
+  players = {},
+  sounds,
+  gameLive
 
 var outgoingListeners = {
   onPlayerMove: null,
@@ -34,125 +48,131 @@ var outgoingListeners = {
   onWeaponPickup: null,
   onItemPickup: null,
   onPlayerTakeDamage: null,
-  onPlayerDied: null
+  onPlayerDied: null,
 }
 
-var handleKeyDown = function (e) {
+var handleKeyDown = function(e) {
   if (keys.valid.indexOf(e.keyCode) > -1) keys.onKeyDown(e)
 }
 
-var handleKeyUp = function (e) {
+var handleKeyUp = function(e) {
   if (keys.valid.indexOf(e.keyCode) > -1) keys.onKeyUp(e)
 }
 
-var updatePlayers = function (playersHash) {
+var updatePlayers = function(playersHash) {
   for (let eachPlayer in playersHash) {
-    let i = playersHash[eachPlayer];
-    if (player.id !== i.id) { // if the new player's socket id isn't the same as this client's
-      if (!players[i.id]) { // if the new player isn't in the current client's game
-        players[i.id] = new Player(i.x, i.y, assets["player" + i.number])
-        players[i.id].id = i.id; // yep thats real
-        players[i.id].number = i.number;
-        players[i.id].spawned = true;
+    let i = playersHash[eachPlayer]
+    if (player.id !== i.id) {
+      // if the new player's socket id isn't the same as this client's
+      if (!players[i.id]) {
+        // if the new player isn't in the current client's game
+        players[i.id] = new Player(i.x, i.y, assets['player' + i.number])
+        players[i.id].id = i.id // yep thats real
+        players[i.id].number = i.number
+        players[i.id].spawned = true
       } else {
-        players[i.id].updateWeaponState(i);
+        players[i.id].updateWeaponState(i)
       }
     } else if (!player.spritesLoaded) {
-      player.number = i.number;
-      player.loadSprites(assets["player" + player.number]);
-      player.setPosition(spawnPoints[i.number]);
+      player.number = i.number
+      player.loadSprites(assets['player' + player.number])
+      player.setPosition(spawnPoints[i.number])
     } else {
       // do the ammo/weapon update
-      player.updateWeaponState(i);
+      player.updateWeaponState(i)
     }
   }
-  delete playersHash[player.id];
-  let remotePlayerIDs = Object.keys(playersHash);
+  delete playersHash[player.id]
+  let remotePlayerIDs = Object.keys(playersHash)
   for (let eachPlayer in players) {
     if (remotePlayerIDs.indexOf(eachPlayer) === -1) {
-      delete players[eachPlayer];
+      delete players[eachPlayer]
     }
   }
 }
 
-var updatePlayer = function (updatedPlayer) {
-  players[updatedPlayer.id].x = updatedPlayer.x;
-  players[updatedPlayer.id].y = updatedPlayer.y;
-  players[updatedPlayer.id].hsp = updatedPlayer.hsp;
-  players[updatedPlayer.id].vsp = updatedPlayer.vsp;
+var updatePlayer = function(updatedPlayer) {
+  players[updatedPlayer.id].x = updatedPlayer.x
+  players[updatedPlayer.id].y = updatedPlayer.y
+  players[updatedPlayer.id].hsp = updatedPlayer.hsp
+  players[updatedPlayer.id].vsp = updatedPlayer.vsp
 }
 
-var createBullet = function (bulletData) {
+var createBullet = function(bulletData) {
   let args = {
     player: {
       x: bulletData.x,
-      y: bulletData.y
+      y: bulletData.y,
     },
     speed: {
       hsp: bulletData.hsp,
-      vsp: bulletData.vsp
-    }
+      vsp: bulletData.vsp,
+    },
   }
-  let newBullet = new Bullet(args, players[bulletData.owner.id], bulletData.damage);
-  players[bulletData.owner.id].setOrientation(getDirection(bulletData));
-  bullets.items.push(newBullet);
+  let newBullet = new Bullet(args, players[bulletData.owner.id], bulletData.damage)
+  players[bulletData.owner.id].setOrientation(getDirection(bulletData))
+  bullets.items.push(newBullet)
 }
 
-var socketPlayerFired = function (bullet) {
+var socketPlayerFired = function(bullet) {
   if (outgoingListeners.onPlayerFire) {
     outgoingListeners.onPlayerFire(bullet)
   }
 }
 
-var socketPlayerMoved = debounce(function () {
-  if (outgoingListeners.onPlayerMove) {
-    outgoingListeners.onPlayerMove(player)
-  }
-}, 8, true); // can tweak this value in future, 8 seems to be ok
+var socketPlayerMoved = debounce(
+  function() {
+    if (outgoingListeners.onPlayerMove) {
+      outgoingListeners.onPlayerMove(player)
+    }
+  },
+  8,
+  true,
+) // can tweak this value in future, 8 seems to be ok
 
-var socketWeaponPickedUp = function (weapon) {
+var socketWeaponPickedUp = function(weapon) {
   if (outgoingListeners.onWeaponPickup) {
-    outgoingListeners.onWeaponPickup({ player: player, weapon: weapon });
+    outgoingListeners.onWeaponPickup({ player: player, weapon: weapon })
   }
 }
 
-var socketItemPickedUp = function (item) {
+var socketItemPickedUp = function(item) {
   if (outgoingListeners.onItemPickup) {
     outgoingListeners.onItemPickup({ player: player, item: item })
   }
 }
 
-var socketTakeDamage = function (value) {
+var socketTakeDamage = function(value) {
   if (outgoingListeners.onTakeDamage) {
-    outgoingListeners.onTakeDamage({ value: value, player: player });
+    outgoingListeners.onTakeDamage({ value: value, player: player })
   }
 }
 
-var socketPlayerDied = function (enemy) {
+var socketPlayerDied = function(enemy) {
   if (outgoingListeners.onPlayerDied) {
     outgoingListeners.onPlayerDied({ player: player, enemy: enemy })
   }
 }
 
-var weaponGone = function (weapon) {
-  mapItems.weapons[weapon.id].active = false;
-  mapItems.weapons[weapon.id].restock();
+var weaponGone = function(weapon) {
+  mapItems.weapons[weapon.id].active = false
+  mapItems.weapons[weapon.id].restock()
 }
 
-var itemGone = function (item) {
-  mapItems.items[item.id].active = false;
-  mapItems.items[item.id].restock();
+var itemGone = function(item) {
+  mapItems.items[item.id].active = false
+  mapItems.items[item.id].restock()
 }
 
-var playerTakeDamage = function (data) {
-  players[data.player.id].takeDamage(data.value);
+var playerTakeDamage = function(data) {
+  players[data.player.id].takeDamage(data.value)
 }
 
-var playerDied = function (data) {
+var playerDied = function(data) {
   if (player.id !== data.player.id) {
     // players[data.player.id].playerDeath(data.enemy);
     setTimeout(() => {
-      players[data.player.id].respawn(data.newX, data.newY);
+      players[data.player.id].respawn(data.newX, data.newY)
     }, 1000)
   } else {
     setTimeout(() => {
@@ -161,155 +181,169 @@ var playerDied = function (data) {
   }
 }
 
-var addPlayerID = function (playerID) {
-  player.id = playerID;
+var addPlayerID = function(playerID) {
+  player.id = playerID
 }
 
-keys = new Keys();
+const quitGame = function() {
+  gameLive = false
+}
+
+keys = new Keys()
 
 var loadAssets = (spriteUrls, soundUrls) => {
-  assetsHelpers.loadSprites(spriteUrls, (spritesArray) => {
-    assets = assetsHelpers.mapSprites(spritesArray);
+  assetsHelpers.loadSprites(spriteUrls, spritesArray => {
+    assets = assetsHelpers.mapSprites(spritesArray)
   })
-  assetsHelpers.loadSounds(soundUrls, (soundsArray) => {
+  assetsHelpers.loadSounds(soundUrls, soundsArray => {
     sounds = assetsHelpers.mapSounds(soundsArray)
   })
 }
 
 //SETUP
 var setup = (canvasWidth, canvasHeight, reqAnimFrame, context, setupListenersCallback) => {
-  raf = reqAnimFrame;
-  ctx = context;
-  startTime = Date.now();
-  canvas.height = canvasHeight;
-  canvas.width = canvasWidth;
-  player = new Player(canvasWidth / 2, canvasHeight / 2, null, socketTakeDamage, socketPlayerDied, true);
-  map = new MapTiles(mapTilesData, assets.tiles);
+  raf = reqAnimFrame
+  ctx = context
+  startTime = Date.now()
+  canvas.height = canvasHeight
+  canvas.width = canvasWidth
+  player = new Player(
+    canvasWidth / 2,
+    canvasHeight / 2,
+    null,
+    socketTakeDamage,
+    socketPlayerDied,
+    true,
+  )
+  map = new MapTiles(mapTilesData, assets.tiles)
   var mapObjectMappings = {
     11: MapObjectFactory.wall,
-    22: MapObjectFactory.dynamic["lava"],
-    33: MapObjectFactory.dynamic["mud"],
-    44: MapObjectFactory.dynamic["ice"],
+    22: MapObjectFactory.dynamic['lava'],
+    33: MapObjectFactory.dynamic['mud'],
+    44: MapObjectFactory.dynamic['ice'],
   }
-  mapObjects = new MapObjects(mapObjectsData, mapObjectMappings);
+  mapObjects = new MapObjects(mapObjectsData, mapObjectMappings)
   var mapItemMappings = {
-    22: MapItemFactory.weapon["assault"],
-    33: MapItemFactory.weapon["shotgun"],
-    44: MapItemFactory.item["health"],
-    55: MapItemFactory.item["overshield"],
-    66: MapItemFactory.item["speedBoost"],
-    77: MapItemFactory.item["cloak"]
+    22: MapItemFactory.weapon['assault'],
+    33: MapItemFactory.weapon['shotgun'],
+    44: MapItemFactory.item['health'],
+    55: MapItemFactory.item['overshield'],
+    66: MapItemFactory.item['speedBoost'],
+    77: MapItemFactory.item['cloak'],
   }
-  mapItems = new MapItems(mapItemsData, mapItemMappings);
-  bullets = new Projectiles("sprites/tiles/bullet.png");
-  setupListenersCallback();
-  main();
-};
+  mapItems = new MapItems(mapItemsData, mapItemMappings)
+  bullets = new Projectiles('sprites/tiles/bullet.png')
+  gameLive = true
+  setupListenersCallback()
+  main()
+}
 
 // UPDATE - RUN MULTIPLE TIMES A SECOND!
-var update = function (delta) {
+var update = function(delta) {
   for (let eachPlayer in players) {
     // players[eachPlayer].calculateWallCollisions(mapObjects.collideable);
     // players[eachPlayer].calculateObjectCollisions(mapObjects.passable);
-    players[eachPlayer].calculateDirection({});
-    players[eachPlayer].calculateVsp();
-    players[eachPlayer].calculateHsp();
-    players[eachPlayer].moveX(delta);
-    players[eachPlayer].moveY(delta);
-    players[eachPlayer].status();
+    players[eachPlayer].calculateDirection({})
+    players[eachPlayer].calculateVsp()
+    players[eachPlayer].calculateHsp()
+    players[eachPlayer].moveX(delta)
+    players[eachPlayer].moveY(delta)
+    players[eachPlayer].status()
   }
   //UPDATE PLAYER POSITION / PASS IN MOVE-KEYS
-  player.calculateDirection(keys.state().movement);
-  player.calculateVsp();
-  player.calculateHsp();
+  player.calculateDirection(keys.state().movement)
+  player.calculateVsp()
+  player.calculateHsp()
   //WALL COLLISIONS
-  player.calculateWallCollisionsVertical(mapObjects.collideable);
-  player.moveY(delta);
-  player.calculateWallCollisionsHorizontal(mapObjects.collideable);
-  player.moveX(delta);
+  player.calculateWallCollisionsVertical(mapObjects.collideable)
+  player.moveY(delta)
+  player.calculateWallCollisionsHorizontal(mapObjects.collideable)
+  player.moveX(delta)
 
   //OBJECT COLLISIONS
-  player.calculateObjectCollisions(mapObjects.passable);
+  player.calculateObjectCollisions(mapObjects.passable)
   //GET SHOT
-  var collidedBullet = player.bulletImpact(bullets.items);
-  if (collidedBullet) bullets.items.splice(bullets.items.indexOf(collidedBullet), 1);
+  var collidedBullet = player.bulletImpact(bullets.items)
+  if (collidedBullet) bullets.items.splice(bullets.items.indexOf(collidedBullet), 1)
   //PICK UP WEAPONS
-  var weapon = player.weaponPickUp(mapItems.weapons);
-  if (weapon) socketWeaponPickedUp(weapon);
+  var weapon = player.weaponPickUp(mapItems.weapons)
+  if (weapon) socketWeaponPickedUp(weapon)
   //PICK UP ITEMS
-  var item = player.itemPickUp(mapItems.items);
-  if (item) socketItemPickedUp(item);
+  var item = player.itemPickUp(mapItems.items)
+  if (item) socketItemPickedUp(item)
   //CHECK STATUS
-  player.status();
+  player.status()
 
-  let { up, down, left, right } = keys.state().movement;
+  let { up, down, left, right } = keys.state().movement
   if (up || down || left || right) {
-    socketPlayerMoved();
+    socketPlayerMoved()
   }
 
   // NEW UP BULLET AND FIRE IN DIRECTION
   if (player.canFire()) {
     // Could loop here/make this code more DRY, but would just involve a loop
     if (keys.state().shooting.up) {
-      var newBullet = player.fireBullet('up');
-      socketPlayerFired(newBullet);
-      bullets.items.push(newBullet);
+      var newBullet = player.fireBullet('up')
+      socketPlayerFired(newBullet)
+      bullets.items.push(newBullet)
     }
     if (keys.state().shooting.down) {
-      var newBullet = player.fireBullet('down');
-      socketPlayerFired(newBullet);
-      bullets.items.push(newBullet);
+      var newBullet = player.fireBullet('down')
+      socketPlayerFired(newBullet)
+      bullets.items.push(newBullet)
     }
     if (keys.state().shooting.left) {
-      var newBullet = player.fireBullet('left');
-      socketPlayerFired(newBullet);
-      bullets.items.push(newBullet);
+      var newBullet = player.fireBullet('left')
+      socketPlayerFired(newBullet)
+      bullets.items.push(newBullet)
     }
     if (keys.state().shooting.right) {
-      var newBullet = player.fireBullet('right');
-      socketPlayerFired(newBullet);
-      bullets.items.push(newBullet);
+      var newBullet = player.fireBullet('right')
+      socketPlayerFired(newBullet)
+      bullets.items.push(newBullet)
     }
   }
   //UPDATE BULLETS X/Y && DELETE WHEN OFF MAP
   // bulletUpdate();
-  bullets.items.forEach(function (bullet) {
+  bullets.items.forEach(function(bullet) {
     bullet.move()
-  });
+  })
   //DESTROY BULLETS THAT ARE OFF CANVAS
-  bullets.detectOffCanvas(canvas.height, canvas.width);
+  bullets.detectOffCanvas(canvas.height, canvas.width)
   //DESTROY BULLETS THAT IMPACT WITH mapObjects
-  bullets.detectWallCollisions(mapObjects.collideable);
+  bullets.detectWallCollisions(mapObjects.collideable)
   //DESTROY BULLETS THAT IMPACT WITH players
-  bullets.detectPlayerCollisions(players);
+  bullets.detectPlayerCollisions(players)
 }
 
-
 //DRAW IMAGES - run constantly
-var render = function (ctx) {
-  var xPos = 0;
-  var yPos = 0;
-  map.render(xPos, yPos, ctx);
-  mapItems.render(ctx);
-  bullets.render(ctx);
-  player.render(ctx);
+var render = function(ctx) {
+  var xPos = 0
+  var yPos = 0
+  map.render(xPos, yPos, ctx)
+  mapItems.render(ctx)
+  bullets.render(ctx)
+  player.render(ctx)
   for (let eachPlayer in players) {
     players[eachPlayer].render(ctx)
   }
-};
+}
 
 //GAME LOOP
-var main = function (currentDelta) {
-  var now = Date.now();
-  var delta = now - startTime;
-  update(currentDelta / 20);
-  render(ctx);
-  startTime = now;
+var main = function(currentDelta) {
+  var now = Date.now()
+  var delta = now - startTime
+  update(currentDelta / 20)
+  render(ctx)
+  startTime = now
   // repeat
-  raf(main.bind(null, delta));
-};
+  console.log('doing a main')
+  raf(() => {
+    if (gameLive) main(delta)
+  })
+}
 
-module.exports.setup = setup;
+module.exports.setup = setup
 module.exports.engine = {
   incoming: {
     updatePlayers: updatePlayers,
@@ -319,17 +353,18 @@ module.exports.engine = {
     weaponGone: weaponGone,
     itemGone: itemGone,
     playerTakeDamage: playerTakeDamage,
-    playerDied: playerDied
+    playerDied: playerDied,
+    quitGame: quitGame,
   },
   outgoing: outgoingListeners,
-  setupKeyListeners: function () {
-    window.addEventListener("keydown", handleKeyDown, false);
-    window.addEventListener("keyup", handleKeyUp, false);
+  setupKeyListeners: function() {
+    window.addEventListener('keydown', handleKeyDown, false)
+    window.addEventListener('keyup', handleKeyUp, false)
   },
-  clearKeyListeners: function () {
-    console.log("cleared listeners!")
-    window.removeEventListener("keydown", handleKeyDown, false);
-    window.removeEventListener("keyup", handleKeyUp, false);
-  }
+  clearKeyListeners: function() {
+    console.log('cleared listeners!')
+    window.removeEventListener('keydown', handleKeyDown, false)
+    window.removeEventListener('keyup', handleKeyUp, false)
+  },
 }
-module.exports.loadAssets = loadAssets;
+module.exports.loadAssets = loadAssets

--- a/client/public/src/canvas/main.js
+++ b/client/public/src/canvas/main.js
@@ -7,59 +7,59 @@ const requestAnimationFrame =
   window.requestAnimationFrame ||
   window.webkitRequestAnimationFrame ||
   window.msRequestAnimationFrame ||
-  window.mozRequestAnimationFrame;
+  window.mozRequestAnimationFrame
 
 const spriteUrls = [
-    //Player 1
+  //Player 1
   '/sprites/characters/player1Up.png',
   '/sprites/characters/player1Down.png',
   '/sprites/characters/player1Left.png',
   '/sprites/characters/player1Right.png',
-    //Player 2
+  //Player 2
   '/sprites/characters/player2Up.png',
   '/sprites/characters/player2Down.png',
   '/sprites/characters/player2Left.png',
   '/sprites/characters/player2Right.png',
-    //Player 3
+  //Player 3
   '/sprites/characters/player3Up.png',
   '/sprites/characters/player3Down.png',
   '/sprites/characters/player3Left.png',
   '/sprites/characters/player3Right.png',
-    //Player 4
+  //Player 4
   '/sprites/characters/player4Up.png',
   '/sprites/characters/player4Down.png',
   '/sprites/characters/player4Left.png',
   '/sprites/characters/player4Right.png',
-    //Weapon PickUps
+  //Weapon PickUps
   '/sprites/items/gun1.png',
   '/sprites/items/gun2.png',
   '/sprites/items/gun3.png',
-    //Item Pickups
+  //Item Pickups
   '/sprites/items/item1.png',
   '/sprites/items/item2.png',
-    //Bullet
+  //Bullet
   '/sprites/tiles/bullet.png',
-    //Tiles
+  //Tiles
   '/sprites/tiles/lava1.png',
   '/sprites/tiles/plat1.png',
   '/sprites/tiles/mud.png',
   '/sprites/tiles/steps1.png',
-  '/sprites/tiles/ice.png'
+  '/sprites/tiles/ice.png',
 ]
 const soundUrls = [
-    //Items
+  //Items
   '/sounds/itemMachineGun.mp3',
   '/sounds/itemShotgun.mp3',
   '/sounds/itemHealth.wav',
   '/sounds/itemOvershield.wav',
-    //Bullets
+  //Bullets
   '/sounds/bulletPistol.wav',
   '/sounds/bulletMachinegun.wav',
   '/sounds/bulletShotgun.wav',
-    //Player
+  //Player
   '/sounds/playerHurt.wav',
   '/sounds/playerDeath.wav',
-  '/sounds/playerReload.aiff'
+  '/sounds/playerReload.aiff',
 ]
 
 export function setupAssets() {
@@ -67,9 +67,10 @@ export function setupAssets() {
 }
 
 export function leave() {
+  engine.incoming.quitGame()
   clearListeners(engine)
 }
 
-export default function run (ctx, canvasWidth, canvasHeight) {
-  setup(canvasWidth, canvasHeight, requestAnimationFrame, ctx, setupListeners(engine));
+export default function run(ctx, canvasWidth, canvasHeight) {
+  setup(canvasWidth, canvasHeight, requestAnimationFrame, ctx, setupListeners(engine))
 }

--- a/client/public/src/canvas/socket.js
+++ b/client/public/src/canvas/socket.js
@@ -1,19 +1,19 @@
-import io from 'socket.io-client';
+import io from 'socket.io-client'
 
 const actions = {} // going soon
-let socket = null;
-export function connect () {
-  if (window.location.hostname === "localhost") {
-    socket = io('http://localhost:8080');
+let socket = null
+export function connect() {
+  if (window.location.hostname === 'localhost') {
+    socket = io('http://localhost:8080')
     return socket
   } else {
-    socket = io('http://crossfire-server.placeofthin.gs');
+    socket = io('http://crossfire-server.placeofthin.gs')
     return socket
   }
 }
 
 export function getID() {
-  return socket.id;
+  return socket.id
 }
 
 // these are communications from react to the socket server
@@ -26,14 +26,14 @@ export const joinGame = (_socket, gameId) => {
 }
 
 export const disconnectGame = (_socket, gameId) => {
-  _socket.emit('quit game', gameId);
+  _socket.emit('quit game', gameId)
 }
 
 // these are communications from the canvas to the socket server
-export function setupListeners (engine) {
+export function setupListeners(engine) {
   return () => {
-    engine.incoming.addPlayerID(socket.id);
-    engine.setupKeyListeners();
+    engine.incoming.addPlayerID(socket.id)
+    engine.setupKeyListeners()
     // listeners to update the engine, from the server
     socket.on('update players', engine.incoming.updatePlayers)
     socket.on('update player', engine.incoming.updatePlayer)
@@ -44,46 +44,46 @@ export function setupListeners (engine) {
     socket.on('remote player died', engine.incoming.playerDied)
 
     // listeners to update the server, from the engine
-    engine.outgoing.onPlayerMove = (player) => {
+    engine.outgoing.onPlayerMove = player => {
       socket.emit('player moved', player)
     }
 
-    engine.outgoing.onPlayerFire = (bullet) => {
+    engine.outgoing.onPlayerFire = bullet => {
       socket.emit('bullet fired', bullet)
     }
 
-    engine.outgoing.onWeaponPickup = (data) => {
+    engine.outgoing.onWeaponPickup = data => {
       socket.emit('weapon picked up', data)
     }
 
-    engine.outgoing.onItemPickup = (item) => {
+    engine.outgoing.onItemPickup = item => {
       socket.emit('item picked up', item)
     }
 
-    engine.outgoing.onTakeDamage = (data) => {
+    engine.outgoing.onTakeDamage = data => {
       socket.emit('player take damage', data)
     }
 
-    engine.outgoing.onPlayerDied = (data) => {
+    engine.outgoing.onPlayerDied = data => {
       socket.emit('player has died', data)
     }
   }
 }
 
-export function clearListeners (engine) {
-  socket.off('update players', actions.refreshPlayers)
-  socket.off('update players', engine.incoming.updatePlayers)
-  socket.off('update player', engine.incoming.updatePlayer)
-  socket.off('create bullet', engine.incoming.createBullet)
-  socket.off('remove weapon', engine.incoming.weaponGone)
-  socket.off('remove item', engine.incoming.itemGone)
-  socket.off('player take damage', engine.incoming.playerTakeDamage)
-  socket.off('remote player died', engine.incoming.playerDied)
-  engine.outgoing.onPlayerMove = null;
-  engine.outgoing.onPlayerFire = null;
-  engine.outgoing.onWeaponPickup = null;
-  engine.outgoing.onItemPickup = null;
-  engine.outgoing.onTakeDamage = null;
-  engine.outgoing.onPlayerDied = null;
-  engine.clearKeyListeners(); // clears key listeners in the engine
+export function clearListeners(engine) {
+  socket.off('update players')
+  socket.off('update players')
+  socket.off('update player')
+  socket.off('create bullet')
+  socket.off('remove weapon')
+  socket.off('remove item')
+  socket.off('player take damage')
+  socket.off('remote player died')
+  engine.outgoing.onPlayerMove = null
+  engine.outgoing.onPlayerFire = null
+  engine.outgoing.onWeaponPickup = null
+  engine.outgoing.onItemPickup = null
+  engine.outgoing.onTakeDamage = null
+  engine.outgoing.onPlayerDied = null
+  engine.clearKeyListeners() // clears key listeners in the engine
 }

--- a/server/engine/index.js
+++ b/server/engine/index.js
@@ -19,7 +19,7 @@ var Keys = require('./utils/keys')
 var getDirection = require('./utils/getDirection')
 var getNumbers = require('./utils/getNumbers')
 
-var Engine = function (canvasWidth, canvasHeight) {
+var Engine = function(canvasWidth, canvasHeight) {
   this.players = {}
   this.bullets = []
   this.entities = this.setupEntities()
@@ -27,39 +27,39 @@ var Engine = function (canvasWidth, canvasHeight) {
   this.eventEmitter = new EventEmitter()
   this.canvas = {
     height: canvasHeight,
-    width: canvasWidth
+    width: canvasWidth,
   }
   this.setupEvents()
-  console.log('engine setup!');
+  // this.randomId = Math.round(Math.random() * 10000)
+  // setInterval(() => {
+  //   console.log(`game: ${this.randomId} has players: ${Object.keys(this.players)}`)
+  // }, 1000)
+  console.log('engine setup id:', this.randomId)
 }
 
-Engine.prototype.setupEvents = function () {
-  this.eventEmitter.on('new player', this.addNewPlayer.bind(this))
-  this.eventEmitter.on('remove player', this.removePlayer.bind(this))
-  this.eventEmitter.on('player moved', this.movePlayer.bind(this))
-  this.eventEmitter.on('bullet fired', this.bulletFired.bind(this))
-  this.eventEmitter.on('weapon picked up', this.weaponPickedUp.bind(this))
-  this.eventEmitter.on('item picked up', this.itemPickedUp.bind(this))
-  this.eventEmitter.on('player take damage', this.playerTakeDamage.bind(this))
-  this.eventEmitter.on('player has died', this.playerDeath.bind(this))
+Engine.prototype.setupEvents = function() {
+  this.eventEmitter.on('new player', data => this.addNewPlayer(data))
+  this.eventEmitter.on('remove player', data => this.removePlayer(data))
+  this.eventEmitter.on('player moved', data => this.movePlayer(data))
+  this.eventEmitter.on('bullet fired', data => this.bulletFired(data))
+  this.eventEmitter.on('weapon picked up', data => this.weaponPickedUp(data))
+  this.eventEmitter.on('item picked up', data => this.itemPickedUp(data))
+  this.eventEmitter.on('player take damage', data => this.playerTakeDamage(data))
+  this.eventEmitter.on('player has died', data => this.playerDeath(data))
 }
 
-Engine.prototype.on = function (eventName, callback) {
-  this.eventEmitter.on(eventName, callback)
-}
-
-Engine.prototype.setupEntities = function () {
+Engine.prototype.setupEntities = function() {
   return new MapItems(mapItemsData, {
-    22: MapItemFactory.weapon["assault"],
-    33: MapItemFactory.weapon["shotgun"],
-    44: MapItemFactory.item["health"],
-    55: MapItemFactory.item["overshield"],
-    66: MapItemFactory.item["speedBoost"],
-    77: MapItemFactory.item["cloak"]
+    22: MapItemFactory.weapon['assault'],
+    33: MapItemFactory.weapon['shotgun'],
+    44: MapItemFactory.item['health'],
+    55: MapItemFactory.item['overshield'],
+    66: MapItemFactory.item['speedBoost'],
+    77: MapItemFactory.item['cloak'],
   })
 }
 
-Engine.prototype.addNewPlayer = function (socketID) {
+Engine.prototype.addNewPlayer = function(socketID) {
   let currentNumbers = getNumbers(this.players)
   let playerNumber
   for (let i = 1; i <= 4; i++) {
@@ -73,14 +73,16 @@ Engine.prototype.addNewPlayer = function (socketID) {
     this.players[socketID] = new Player(spawn.x, spawn.y, socketID, playerNumber)
     this.eventEmitter.emit('update players', this.players)
   }
+  console.log('added a player so this.players keys:', Object.keys(this.players))
 }
 
-Engine.prototype.removePlayer = function (socketID) {
+Engine.prototype.removePlayer = function(socketID) {
+  console.log('removed a player with socket id:', socketID)
   delete this.players[socketID]
   this.eventEmitter.emit('update players', this.players)
 }
 
-Engine.prototype.movePlayer = function (player) {
+Engine.prototype.movePlayer = function(player) {
   let playerToMove = this.players[player.id]
   playerToMove.x = player.x
   playerToMove.y = player.y
@@ -89,16 +91,16 @@ Engine.prototype.movePlayer = function (player) {
   this.eventEmitter.emit('update player', playerToMove)
 }
 
-Engine.prototype.bulletFired = function (bullet) {
+Engine.prototype.bulletFired = function(bullet) {
   let args = {
     player: {
       x: bullet.x,
-      y: bullet.y
+      y: bullet.y,
     },
     speed: {
       hsp: bullet.hsp,
-      vsp: bullet.vsp
-    }
+      vsp: bullet.vsp,
+    },
   }
   let bulletOwner = this.players[bullet.owner.id]
   // this only gets fired if the client can actually fire a bullet
@@ -117,7 +119,7 @@ Engine.prototype.bulletFired = function (bullet) {
   }
 }
 
-Engine.prototype.weaponPickedUp = function (data) {
+Engine.prototype.weaponPickedUp = function(data) {
   this.entities.weapons[data.weapon.id].active = false
   this.entities.weapons[data.weapon.id].restock()
   this.players[data.player.id].giveWeapon(data.weapon)
@@ -125,7 +127,7 @@ Engine.prototype.weaponPickedUp = function (data) {
   this.eventEmitter.emit('update players', this.players)
 }
 
-Engine.prototype.itemPickedUp = function (data) {
+Engine.prototype.itemPickedUp = function(data) {
   this.entities.items[data.item.id].active = false
   this.entities.items[data.item.id].restock(this.entities.items[data.item.id].respawnTime)
   this.players[data.player.id].giveItem(data.item)
@@ -133,13 +135,13 @@ Engine.prototype.itemPickedUp = function (data) {
   this.eventEmitter.emit('update players', this.players)
 }
 
-Engine.prototype.playerTakeDamage = function (data) {
+Engine.prototype.playerTakeDamage = function(data) {
   this.players[data.player.id].takeDamage(data.value)
   this.eventEmitter.emit('on player take damage', data)
   this.eventEmitter.emit('update players', this.players)
 }
 
-Engine.prototype.playerDeath = function (data) {
+Engine.prototype.playerDeath = function(data) {
   const newPosition = spawnPoints(Math.ceil(Math.random() * 4))
   this.players[data.player.id].playerDeath(data.enemy, this.players)
   this.players[data.player.id].health = 4
@@ -147,9 +149,9 @@ Engine.prototype.playerDeath = function (data) {
     player: data.player,
     enemy: data.enemy,
     newX: newPosition.x,
-    newY: newPosition.y
+    newY: newPosition.y,
   })
   this.eventEmitter.emit('update players', this.players)
 }
 
-module.exports = Engine
+export default Engine

--- a/server/index.js
+++ b/server/index.js
@@ -1,67 +1,66 @@
-var app = require('express')();
-var server = require('http').Server(app);
-var io = require('socket.io')(server);
-var Simulation = require('./simulation.js');
-var games = {};
-server.listen(8080);
+var app = require('express')()
+var server = require('http').Server(app)
+var io = require('socket.io')(server)
+import Simulation from './simulation'
+const games = {}
+server.listen(8080)
 
-app.get('/', function (req, res) {
-  res.sendFile(__dirname + '/error_page.html');
-});
+app.get('/', function(req, res) {
+  res.sendFile(__dirname + '/error_page.html')
+})
 
-io.on('connection', function (socket) {
-  socket.emit('games refresh', gameList());
-  socket.on('create game', function (data) {
-    disconnectSocketFromGames(socket);
-    var simulation = new Simulation({name: data, height: 512, width: 768}, io);
-    games[data] = simulation;
-    io.emit('games refresh', gameList());
-  });
-
-  socket.on('join game', function (data) {
-    disconnectSocketFromGames(socket);
-    connectSocketToGame(games[data], socket);
+io.on('connection', function(socket) {
+  socket.emit('games refresh', gameList())
+  socket.on('create game', function(data) {
+    disconnectSocketFromGames(socket)
+    const simulation = new Simulation({ name: data, height: 512, width: 768 }, io)
+    games[data] = simulation
+    io.emit('games refresh', gameList())
   })
 
-  socket.on('quit game', function (data) {
-    disconnectSocketFromGames(socket);
-  });
-  socket.on('disconnect', function () {
-    disconnectSocketFromGames(socket);
-  });
+  socket.on('join game', function(data) {
+    disconnectSocketFromGames(socket)
+    connectSocketToGame(games[data], socket)
+  })
 
-});
+  socket.on('quit game', function(data) {
+    disconnectSocketFromGames(socket)
+  })
+  socket.on('disconnect', function() {
+    disconnectSocketFromGames(socket)
+  })
+})
 
-var forEachSimulation = function (callback) {
-  for(var simulationKey in games) {
-    if(games.hasOwnProperty(simulationKey)) {
-        callback(games[simulationKey]);
+const forEachSimulation = function(callback) {
+  for (let simulationKey in games) {
+    if (games.hasOwnProperty(simulationKey)) {
+      callback(games[simulationKey])
     }
   }
 }
 
-var gameList = function () {
-  var result = {}
-  forEachSimulation((game) => {
+const gameList = function() {
+  const result = {}
+  forEachSimulation(game => {
     result[game.name] = {
-      playersState: [game.playerCount(), game.maxPlayers]
+      playersState: [game.playerCount(), game.maxPlayers],
     }
   })
-  return result;
+  return result
 }
 
-var connectSocketToGame = function (simulation, socket) {
+const connectSocketToGame = function(simulation, socket) {
   socket.join(simulation.name)
-  simulation.connectPlayer(socket);
+  simulation.connectPlayer(socket)
 }
 
-var disconnectSocketFromGames = function (socket) {
-  forEachSimulation((simulation) => {
+const disconnectSocketFromGames = function(socket) {
+  forEachSimulation(simulation => {
     simulation.disconnectPlayer(socket, () => {
       socket.leave(simulation.name)
       console.log(socket.id, 'left room:', simulation.name)
-    });
+    })
   })
 }
 
-console.log('Socket Server started at http://localhost:8080');
+console.log('Socket Server started at http://localhost:8080')

--- a/server/simulation.js
+++ b/server/simulation.js
@@ -1,130 +1,124 @@
 // var Canvas = require('canvas');
-var Engine = require('./engine');
+import Engine from './engine'
 
-var Simulation = function (data, io) {
-  this.name = data.name;
-  this.players = {};
-  this.maxPlayers = data.maxPlayers || 4;
-  // this.canvas = new Canvas(data.width, data.height)
-  // this.ctx = this.canvas.getContext('2d');
-  this.serverEngine = new Engine(data.width, data.height);
-  this.io = io;
+const Simulation = function(data, io) {
+  this.name = data.name
+  this.players = {}
+  this.maxPlayers = data.maxPlayers || 4
+  this.serverEngine = new Engine(data.width, data.height)
+  this.io = io
 
-  // these are listeners to the server engine, to broadcast events over the socket
-  this.setupListeners();
+  this.randomId = Math.round(Math.random() * 10000)
+  console.log('setup a simulation with id:', this.randomId)
+
+  this.setupListeners()
 }
 
-Simulation.prototype.playerCount = function () {
-  return Object.keys(this.players).length;
+Simulation.prototype.playerCount = function() {
+  return Object.keys(this.players).length
 }
 
-Simulation.prototype.playerIDs = function () {
+Simulation.prototype.playerIDs = function() {
   return Object.keys(this.players)
 }
 
-Simulation.prototype.setupListeners = function () {
+Simulation.prototype.setupListeners = function() {
   // convert these to new server-engine setup
-  let engine = this.serverEngine.eventEmitter;
-  engine.on('update players', this.updatePlayers.bind(this));
-  engine.on('update player', this.updatePlayer.bind(this));
-  engine.on('create bullet', this.createBullet.bind(this));
-  engine.on('remove weapon', this.removeWeapon.bind(this));
-  engine.on('remove item', this.removeItem.bind(this));
-  engine.on('on player take damage', this.playerTakeDamage.bind(this));
-  engine.on('on player death', this.playerDeath.bind(this));
+  let engine = this.serverEngine.eventEmitter
+  engine.on('update players', this.updatePlayers.bind(this))
+  engine.on('update player', this.updatePlayer.bind(this))
+  engine.on('create bullet', this.createBullet.bind(this))
+  engine.on('remove weapon', this.removeWeapon.bind(this))
+  engine.on('remove item', this.removeItem.bind(this))
+  engine.on('on player take damage', this.playerTakeDamage.bind(this))
+  engine.on('on player death', this.playerDeath.bind(this))
 }
 
 // HANDLERS FOR THE SERVER ENGINE EMITTING EVENTS
 
-Simulation.prototype.updatePlayers = function (playersHash) {
-  this.io.sockets.in(this.name).emit('update players', playersHash);
+Simulation.prototype.updatePlayers = function(playersHash) {
+  this.io.sockets.in(this.name).emit('update players', playersHash)
 }
 
-Simulation.prototype.updatePlayer = function (player) {
-  this.players[player.id].to(this.name).broadcast.emit('update player', player);
+Simulation.prototype.updatePlayer = function(player) {
+  this.players[player.id].to(this.name).broadcast.emit('update player', player)
 }
 
-Simulation.prototype.createBullet = function (bulletData) {
-  this.players[bulletData.owner.id].to(this.name).broadcast.emit('create bullet', bulletData);
+Simulation.prototype.createBullet = function(bulletData) {
+  this.players[bulletData.owner.id].to(this.name).broadcast.emit('create bullet', bulletData)
 }
 
-Simulation.prototype.removeWeapon = function (weaponData) {
-  this.io.sockets.in(this.name).emit('remove weapon', weaponData);
+Simulation.prototype.removeWeapon = function(weaponData) {
+  this.io.sockets.in(this.name).emit('remove weapon', weaponData)
 }
 
-Simulation.prototype.removeItem = function (itemData) {
+Simulation.prototype.removeItem = function(itemData) {
   this.io.sockets.in(this.name).emit('remove item', itemData)
 }
 
-Simulation.prototype.playerTakeDamage = function (data) {
+Simulation.prototype.playerTakeDamage = function(data) {
   this.players[data.player.id].to(this.name).broadcast.emit('player take damage', data)
 }
 
-Simulation.prototype.playerDeath = function (data) {
-  this.io.sockets.in(this.name).emit('remote player died', data);
+Simulation.prototype.playerDeath = function(data) {
+  this.io.sockets.in(this.name).emit('remote player died', data)
 }
 
-Simulation.prototype.setupEvents = function (socket) {
+Simulation.prototype.setupEvents = function(socket) {
   // this is to setup the server for any events the client might emit
-  socket.on('player moved', this.movePlayer.bind(this))
-  socket.on('bullet fired', this.bulletFired.bind(this))
-  socket.on('weapon picked up', this.weaponPickedUp.bind(this))
-  socket.on('item picked up', this.itemPickedUp.bind(this))
-  socket.on('player take damage', this.playerDamaged.bind(this))
-  socket.on('player has died', this.playerDied.bind(this))
+  socket.on('player moved', data => this.movePlayer(data))
+  socket.on('bullet fired', data => this.bulletFired(data))
+  socket.on('weapon picked up', data => this.weaponPickedUp(data))
+  socket.on('item picked up', data => this.itemPickedUp(data))
+  socket.on('player take damage', data => this.playerDamaged(data))
+  socket.on('player has died', data => this.playerDied(data))
+}
+
+Simulation.prototype.movePlayer = function(data) {
+  this.serverEngine.eventEmitter.emit('player moved', data)
+}
+Simulation.prototype.bulletFired = function(data) {
+  this.serverEngine.eventEmitter.emit('bullet fired', data)
+}
+Simulation.prototype.weaponPickedUp = function(data) {
+  this.serverEngine.eventEmitter.emit('weapon picked up', data)
+}
+Simulation.prototype.itemPickedUp = function(data) {
+  this.serverEngine.eventEmitter.emit('item picked up', data)
+}
+Simulation.prototype.playerDamaged = function(data) {
+  this.serverEngine.eventEmitter.emit('player take damage', data)
+}
+Simulation.prototype.playerDied = function(data) {
+  this.serverEngine.eventEmitter.emit('player has died', data)
 }
 
 // HANDLERS FOR THE SOCKET EMITTING EVENTS
 
-Simulation.prototype.connectPlayer = function (socket) {
-  this.serverEngine.eventEmitter.emit('new player', socket.id);
-  this.setupEvents(socket);
-  this.players[socket.id] = socket;
+Simulation.prototype.connectPlayer = function(socket) {
+  this.serverEngine.eventEmitter.emit('new player', socket.id)
+  this.setupEvents(socket)
+  this.players[socket.id] = socket
 }
 
-Simulation.prototype.disconnectPlayer = function (socket, callback) {
+Simulation.prototype.disconnectPlayer = function(socket, callback) {
   if (this.players[socket.id]) {
-    this.serverEngine.eventEmitter.emit('remove player', socket.id);
-    delete this.players[socket.id];
-    this.clearEvents(socket);
-    callback();
+    this.serverEngine.eventEmitter.emit('remove player', socket.id)
+    delete this.players[socket.id]
+    this.clearEvents(socket)
+    callback()
   }
 }
 
-Simulation.prototype.movePlayer = function (data) {
-  this.serverEngine.eventEmitter.emit('player moved', data);
-}
-
-Simulation.prototype.bulletFired = function (data) {
-  this.serverEngine.eventEmitter.emit('bullet fired', data);
-}
-
-Simulation.prototype.weaponPickedUp = function (data) {
-  this.serverEngine.eventEmitter.emit('weapon picked up', data);
-}
-
-Simulation.prototype.itemPickedUp = function (data) {
-  this.serverEngine.eventEmitter.emit('item picked up', data);
-}
-
-Simulation.prototype.playerDamaged = function (data) {
-  this.serverEngine.eventEmitter.emit('player take damage', data);
-}
-
-Simulation.prototype.playerDied = function (data) {
-  this.serverEngine.eventEmitter.emit('player has died', data);
-}
-
-Simulation.prototype.clearEvents = function (socket) {
+Simulation.prototype.clearEvents = function(socket) {
   // this is to remove the events created in setupEvents()
-  socket.removeListener('player moved', this.movePlayer)
-  socket.removeListener('bullet fired', this.bulletFired)
-  socket.removeListener('weapon picked up', this.weaponPickedUp)
-  socket.removeListener('item picked up', this.itemPickedUp)
-  socket.removeListener('player take damage', this.playerDamaged)
-  socket.removeListener('player has died', this.playerDeath)
+  socket
+    .removeAllListeners(['player moved'])
+    .removeAllListeners(['bullet fired'])
+    .removeAllListeners(['weapon picked up'])
+    .removeAllListeners(['item picked up'])
+    .removeAllListeners(['player take damage'])
+    .removeAllListeners(['player has died'])
 }
 
-
-
-module.exports = Simulation;
+export default Simulation


### PR DESCRIPTION
Fixes #1 and some other buggy behaviour.

Includes a bunch of `prettier` changes so the notable parts are: 
* the `removeAllListeners` calls in `simulation.js` makes sure that when a socket disconnects from a simulation, it doesn't continue to post events to that simulation
* the `gameLive` boolean on client side in the engine that is `true` when game gets setup, then becomes `false` when the user leaves the game.